### PR TITLE
feat(5) : generalLogin and Logout api 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'  // jwt 토큰
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'  // jwt 토큰
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3' // jwt 토큰
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.security:spring-security-oauth2-jose'
 
 
 	compileOnly 'org.projectlombok:lombok' // 롬복 사용

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket' // 웹소켓 사용
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6' // 타임리프와 스프링 시큐리티 통합
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2' // Swagger 의존성
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'  // jwt 토큰
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'  // jwt 토큰
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3' // jwt 토큰
+
+
 	compileOnly 'org.projectlombok:lombok' // 롬복 사용
 	annotationProcessor 'org.projectlombok:lombok' // 롬복 어노테이션 프로세서
 	testImplementation 'org.springframework.boot:spring-boot-starter-test' // 테스트용 스프링 부트 스타터

--- a/src/main/java/DevBackEnd/ForLong/Config/SecurityConfig.java
+++ b/src/main/java/DevBackEnd/ForLong/Config/SecurityConfig.java
@@ -84,6 +84,9 @@ public class SecurityConfig {
         /**
          * Custom FormLogin Filter And Custom Logout Filter
          * */
+        http.
+                addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
         http
                 .addFilterAt(new LoginFilter(authenticationManager(configuration), jwtUtil, cookieUtil, refreshRepository),
                         UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/DevBackEnd/ForLong/Config/SecurityConfig.java
+++ b/src/main/java/DevBackEnd/ForLong/Config/SecurityConfig.java
@@ -1,13 +1,27 @@
 package DevBackEnd.ForLong.Config;
 
+import DevBackEnd.ForLong.Filter.CutomLogoutFilter;
+import DevBackEnd.ForLong.Filter.JWTFilter;
+import DevBackEnd.ForLong.Filter.LoginFilter;
+import DevBackEnd.ForLong.Repository.RefreshRepository;
+import DevBackEnd.ForLong.Util.CookieUtil;
+import DevBackEnd.ForLong.Util.JwtUtil;
 import DevBackEnd.ForLong.Util.PasswordUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -18,20 +32,76 @@ import java.util.Collections;
 @EnableWebSecurity
 public class SecurityConfig {
 
+
+    private final AuthenticationConfiguration configuration;
+    private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
+    private final RefreshRepository refreshRepository;
+
+    public SecurityConfig(AuthenticationConfiguration configuration, JwtUtil jwtUtil, CookieUtil cookieUtil, RefreshRepository refreshRepository) {
+        this.configuration = configuration;
+        this.jwtUtil = jwtUtil;
+        this.cookieUtil = cookieUtil;
+        this.refreshRepository = refreshRepository;
+    }
+
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        /**
+         * 접근 가능한 url detail modify
+         * */
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/**").permitAll()
                         .anyRequest().authenticated()
                 );
 
+        /**
+         * csrf 보호 해제
+         * */
+        http
+                .csrf((csrf) -> csrf.disable());
+
+        /**
+         * 커스텀 로그인, 로그아웃 필터 사용
+         * */
+        http
+                .formLogin((formLogin) -> formLogin.disable())
+                .logout((formLogout) -> formLogout.disable());
+
+
+        /**
+         * Custom FormLogin Filter And Custom Logout Filter
+         * */
+        http
+                .addFilterAt(new LoginFilter(authenticationManager(configuration), jwtUtil, cookieUtil, refreshRepository),
+                        UsernamePasswordAuthenticationFilter.class);
+        http
+                .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);
+
+        http
+                .addFilterBefore(new CutomLogoutFilter(jwtUtil, refreshRepository), LogoutFilter.class);
+
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                );
+
+
+        /**
+         * cors 관련 설정
+         * */
         http
                 .cors((cors) -> cors
                         .configurationSource(new CorsConfigurationSource() {
@@ -50,13 +120,6 @@ public class SecurityConfig {
                                 return config;
                             }
                         }));
-        http
-                .csrf((csrf) -> csrf.disable());
-
-
-        http
-                .formLogin((formLogin) -> formLogin.disable());
-        // 커스텀 로그인 API 사용
 
         return http.build();
     }

--- a/src/main/java/DevBackEnd/ForLong/Controller/JoinController.java
+++ b/src/main/java/DevBackEnd/ForLong/Controller/JoinController.java
@@ -31,7 +31,7 @@ public class JoinController {
      * 회원가입 과정
      * */
     @Operation(summary = "회원가입 처리", description = "회원 정보를 받아 회원가입을 처리합니다." +
-            "joinId, password, email, phone, nickname 정보를 받아 회원가입을 처리하빈다." +
+            "loginId, password, email, phone, nickname 정보를 받아 회원가입을 처리하빈다." +
             "email은 선택이고 나머지는 모두 필수 입력 값입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "회원가입 성공"),

--- a/src/main/java/DevBackEnd/ForLong/Controller/UserController.java
+++ b/src/main/java/DevBackEnd/ForLong/Controller/UserController.java
@@ -8,10 +8,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api")
 public class UserController {
 
     /**

--- a/src/main/java/DevBackEnd/ForLong/Controller/UserController.java
+++ b/src/main/java/DevBackEnd/ForLong/Controller/UserController.java
@@ -1,0 +1,58 @@
+package DevBackEnd.ForLong.Controller;
+
+import DevBackEnd.ForLong.Dto.ApiResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+
+    /**
+     * 실제 로그인 로직은 LoginFilter를 통해 구현됨.
+     * 이 코드는 프론트앤드 개발자를 위한 명세서를 위해 적은 코드
+     * */
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공 시 JWT 토큰 반환"),
+            @ApiResponse(responseCode = "401", description = "로그인 실패 (잘못된 자격 증명)"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (필수 파라미터 누락)")
+    })
+    @Operation(summary = "로그인 로직 (Swagger 명세 전용)", description = "userId와 password를 포함하여 POST /login으로 요청을 보내면 기본 로그인 로직이 실행됩니다. " +
+            "이 엔드포인트는 실제 요청을 처리하지 않고 문서화를 위해 제공됩니다"+"프론트엔드 팀은 JWT 토큰을 localStorage나 sessionStorage에 저장한 뒤," +
+            " 인증이 필요한 API 요청 시 Authorization: Bearer <JWT 토큰> 형식으로 요청 헤더에 포함해 보내야 합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponseDTO<Void>> loginProc(
+            @Parameter(description = "사용자 ID", required = true) @RequestParam(name = "userId") @NotBlank String userId,
+            @Parameter(description = "사용자 비밀번호", required = true) @RequestParam(name = "password") @NotBlank String password) {
+        ApiResponseDTO<Void> response = new ApiResponseDTO<>("success","로그인 성공",null);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 로그아웃
+     * 실제 관련 로직은 filter 단에서 움직임.
+     * 프론트 개발자를 위한 api 명세서를 위한 코드
+     * */
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @Operation(summary = "로그아웃 로직 (Swagger 명세 전용)",
+            description = "POST /logout 요청을 보내면 클라이언트 측에서 JWT 토큰을 삭제해 로그아웃을 처리합니다. 이 엔드포인트는 실제 서버에서 처리하지 않고, 문서화를 위해 제공됩니다."+
+                    "로그아웃 요청 시 클라이언트 측에서 저장된 JWT 토큰을 삭제해야 합니다. " +
+                    "서버는 세션을 사용하지 않으므로 JWT 기반에서는 토큰 자체를 삭제하는 것이 곧 로그아웃을 의미")
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponseDTO<Void>> logoutProc(){
+        ApiResponseDTO<Void> response = new ApiResponseDTO<>("success", "로그아웃 성공", null);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/DevBackEnd/ForLong/Converter/JoinConverter.java
+++ b/src/main/java/DevBackEnd/ForLong/Converter/JoinConverter.java
@@ -9,7 +9,7 @@ public class JoinConverter {
 
     public static JoinDTO toDTO(User user) {
         return new JoinDTO(
-                user.getJoinId(),
+                user.getLoginId(),
                 user.getPassword(),
                 user.getNickname(),
                 user.getEmail(),
@@ -22,7 +22,7 @@ public class JoinConverter {
         log.info("JoinDTO 변환 시작 : {}", joinDTO.toString());
         User user = new User();
 
-        user.setJoinId(joinDTO.getUserId());
+        user.setLoginId(joinDTO.getLoginId());
         user.setPassword(joinDTO.getPassword());
         user.setNickname(joinDTO.getNickname());
         user.setEmail(joinDTO.getEmail());

--- a/src/main/java/DevBackEnd/ForLong/Converter/JoinConverter.java
+++ b/src/main/java/DevBackEnd/ForLong/Converter/JoinConverter.java
@@ -22,7 +22,7 @@ public class JoinConverter {
         log.info("JoinDTO 변환 시작 : {}", joinDTO.toString());
         User user = new User();
 
-        user.setLoginId(joinDTO.getLoginId());
+        user.setLoginId(joinDTO.getLogin_id());
         user.setPassword(joinDTO.getPassword());
         user.setNickname(joinDTO.getNickname());
         user.setEmail(joinDTO.getEmail());

--- a/src/main/java/DevBackEnd/ForLong/Dto/CustomUserDetail.java
+++ b/src/main/java/DevBackEnd/ForLong/Dto/CustomUserDetail.java
@@ -1,0 +1,80 @@
+package DevBackEnd.ForLong.Dto;
+
+import DevBackEnd.ForLong.Entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+
+// OAuth방식 로그인
+// 스프링 시큐리티와의 통합을 위함
+public class CustomUserDetail implements UserDetails, OAuth2User {
+
+    private final User user;
+    private Map<String, Object> attributes;
+
+
+    public CustomUserDetail(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getName() {
+        return user.getNickname();
+    }
+
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Collections.unmodifiableMap(attributes);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        return Stream.of(new SimpleGrantedAuthority(user.getRole()))
+                .collect(toList());
+    }
+
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getLoginId();
+    }
+
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/DevBackEnd/ForLong/Dto/CustomUserDetail.java
+++ b/src/main/java/DevBackEnd/ForLong/Dto/CustomUserDetail.java
@@ -1,6 +1,7 @@
 package DevBackEnd.ForLong.Dto;
 
 import DevBackEnd.ForLong.Entity.User;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -18,6 +19,7 @@ import static java.util.stream.Collectors.toList;
 // 스프링 시큐리티와의 통합을 위함
 public class CustomUserDetail implements UserDetails, OAuth2User {
 
+    @Getter
     private final User user;
     private Map<String, Object> attributes;
 
@@ -35,7 +37,7 @@ public class CustomUserDetail implements UserDetails, OAuth2User {
 
     @Override
     public Map<String, Object> getAttributes() {
-        return Collections.unmodifiableMap(attributes);
+        return attributes != null ? Collections.unmodifiableMap(attributes) : Collections.emptyMap();
     }
 
     @Override

--- a/src/main/java/DevBackEnd/ForLong/Dto/CustomUserDetailService.java
+++ b/src/main/java/DevBackEnd/ForLong/Dto/CustomUserDetailService.java
@@ -1,0 +1,31 @@
+package DevBackEnd.ForLong.Dto;
+
+import DevBackEnd.ForLong.Entity.User;
+import DevBackEnd.ForLong.Repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        log.info("Authenticating user: {}", loginId);
+
+        User user = userRepository.findByLoginId(loginId);
+        if (user == null) {
+            throw new UsernameNotFoundException("User not found : " + loginId);
+        }
+        return new CustomUserDetail(user,null);
+    }
+}

--- a/src/main/java/DevBackEnd/ForLong/Dto/JoinDTO.java
+++ b/src/main/java/DevBackEnd/ForLong/Dto/JoinDTO.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Setter
 public class JoinDTO {
 
-    private String loginId;
+    private String login_id;
     private String password;
     private String nickname;
     private String email;
@@ -16,7 +16,7 @@ public class JoinDTO {
 
     public JoinDTO(String loginId, String password, String nickname,
                    String email, String phone, String role){
-        this.loginId = loginId;
+        this.login_id = loginId;
         this.password = password;
         this.nickname = nickname;
         this.email = email;

--- a/src/main/java/DevBackEnd/ForLong/Dto/JoinDTO.java
+++ b/src/main/java/DevBackEnd/ForLong/Dto/JoinDTO.java
@@ -7,16 +7,16 @@ import lombok.Setter;
 @Setter
 public class JoinDTO {
 
-    private String userId;
+    private String loginId;
     private String password;
     private String nickname;
     private String email;
     private String phone;
     private String role;
 
-    public JoinDTO(String joinId, String password, String nickname,
+    public JoinDTO(String loginId, String password, String nickname,
                    String email, String phone, String role){
-        this.userId = joinId;
+        this.loginId = loginId;
         this.password = password;
         this.nickname = nickname;
         this.email = email;

--- a/src/main/java/DevBackEnd/ForLong/Dto/LoginDTO.java
+++ b/src/main/java/DevBackEnd/ForLong/Dto/LoginDTO.java
@@ -1,0 +1,8 @@
+package DevBackEnd.ForLong.Dto;
+
+public class LoginDTO {
+
+    private String loginId;
+
+
+}

--- a/src/main/java/DevBackEnd/ForLong/Dto/LoginDTO.java
+++ b/src/main/java/DevBackEnd/ForLong/Dto/LoginDTO.java
@@ -1,8 +1,14 @@
 package DevBackEnd.ForLong.Dto;
 
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class LoginDTO {
 
     private String loginId;
-
+    private String password;
 
 }

--- a/src/main/java/DevBackEnd/ForLong/Entity/User.java
+++ b/src/main/java/DevBackEnd/ForLong/Entity/User.java
@@ -22,8 +22,8 @@ public class User {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @Column(name = "join_id", nullable = false, unique = true)
-    private String joinId;
+    @Column(name = "login_id", nullable = false, unique = true)
+    private String loginId;
 
     private String password;
 

--- a/src/main/java/DevBackEnd/ForLong/Filter/CutomLogoutFilter.java
+++ b/src/main/java/DevBackEnd/ForLong/Filter/CutomLogoutFilter.java
@@ -1,0 +1,118 @@
+package DevBackEnd.ForLong.Filter;
+
+import DevBackEnd.ForLong.Repository.RefreshRepository;
+import DevBackEnd.ForLong.Util.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+public class CutomLogoutFilter extends GenericFilterBean {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    public CutomLogoutFilter(JwtUtil jwtUtil, RefreshRepository refreshRepository) {
+        this.jwtUtil = jwtUtil;
+        this.refreshRepository = refreshRepository;
+    }
+
+    @Override
+    public void doFilter(ServletRequest httpRequest, ServletResponse httpResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+//        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+        HttpServletRequest request = (HttpServletRequest) httpRequest;
+        HttpServletResponse response = (HttpServletResponse) httpResponse;
+
+        /**
+         * /logout 요청 낚아챔
+         * */
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/api/logout$")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+
+        /**
+         * POST 요청 맊아챔.
+         * */
+        if (!requestMethod.equals("POST")) {  //logout 요청 + POST 요청만 낚아챔.
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        /**
+         * 쿠키에서 Refresh 토큰 가져오기
+         * */
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        refresh = getRefresh(cookies, refresh);
+
+        /**
+         * 쿠키가 null인 경우 400 오류 발생
+         * */
+        if (refresh == null) {
+            getSetStatus(response);
+            return;
+        }
+
+        //만료 체크
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            //response status code
+            getSetStatus(response);
+            throw e;
+        }
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+            //response status code
+            getSetStatus(response);
+            return;
+        }
+
+        //DB에 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+            //response status code
+            getSetStatus(response);
+            return;
+        }
+
+        //로그아웃 진행
+        //Refresh 토큰 DB에서 제거
+        refreshRepository.deleteByRefresh(refresh);
+
+        //Refresh 토큰 Cookie 값 0
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+
+
+    private void getSetStatus(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    private String getRefresh(Cookie[] cookies, String refresh) {
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refresh")) {
+                refresh = cookie.getValue();
+            }
+        }
+        return refresh;
+    }
+}

--- a/src/main/java/DevBackEnd/ForLong/Filter/JWTFilter.java
+++ b/src/main/java/DevBackEnd/ForLong/Filter/JWTFilter.java
@@ -1,0 +1,138 @@
+package DevBackEnd.ForLong.Filter;
+
+import DevBackEnd.ForLong.Dto.CustomUserDetail;
+import DevBackEnd.ForLong.Entity.User;
+import DevBackEnd.ForLong.Util.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JWTFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+        if (path.startsWith("/swagger-ui") ||
+                path.startsWith("/v3/api-docs") ||
+                path.startsWith("/swagger-resources") ||
+                path.startsWith("/**")
+        ) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+//        String authorization = request.getHeader("Authorization");
+        String accessToken = request.getHeader("access");
+
+        // 토큰이 없다면 다음 필터로 넘김
+        if (accessToken == null) {
+
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+        // 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e) {
+
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("access token expired");
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        // 헤더에 Authorization 정보가 없을 경우 쿠키에서 토큰 검색
+        if (accessToken == null || accessToken.isEmpty()) {
+            accessToken = getTokenFromCookies(request.getCookies());
+            if (accessToken != null) {
+                // 쿠키에서 가져온 토큰을 Authorization 헤더로 설정
+                response.setHeader("Authorization", "Bearer " + accessToken);
+            }
+        }
+
+        // 최종적으로 Authorization이 null일 경우 필터 진행 후 종료
+        if (accessToken == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String category = jwtUtil.getCategory(accessToken);
+
+        // 엑세스 토큰인지 검증
+        if (!category.equals("access")) {
+
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("invalid access token");
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        // 헤더에 Auth 정보가 없을 경우 쿠키에서 토큰 검색
+        String token = accessToken.replace("Bearer ", "");
+
+        setUpAuthentication(token);
+        filterChain.doFilter(request, response);
+    }
+
+    // 쿠키에서 토큰을 가져오는 메서드
+    private String getTokenFromCookies(Cookie[] cookies) {
+        if (cookies == null) return null;
+        for (Cookie cookie : cookies) {
+            if ("Authorization".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    private void setUpAuthentication(String token) {
+        String loginId = jwtUtil.getUserId(token);
+        String role = jwtUtil.getRole(token);
+
+        User user = new User();  //user를 생성하여 값 set
+        user.setLoginId(loginId);
+        user.setRole(role);
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("loginId", loginId);
+        attributes.put("role", role);
+
+        CustomUserDetail customOAuth2User = new CustomUserDetail(user, attributes); // UserDetails에 회원 정보 객체 담기
+
+        // 스프링이 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
+        // 세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+}
+
+/**
+ *  Authorization 정보를 클라이언트가 사용해야 할 경우에는 response.setHeader를 사용하고, 서버에서만 참조할 경우에는 request.setAttribute가 적합
+ * */

--- a/src/main/java/DevBackEnd/ForLong/Filter/LoginFilter.java
+++ b/src/main/java/DevBackEnd/ForLong/Filter/LoginFilter.java
@@ -1,0 +1,146 @@
+package DevBackEnd.ForLong.Filter;
+
+import DevBackEnd.ForLong.Dto.LoginDTO;
+import DevBackEnd.ForLong.Entity.RefreshToken;
+import DevBackEnd.ForLong.Repository.RefreshRepository;
+import DevBackEnd.ForLong.Util.CookieUtil;
+import DevBackEnd.ForLong.Util.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+
+@Slf4j
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    public static final long ACCESSMS = 60 * 60 * 1000L;
+    public static final long REFRESHMS = 24 * 60 * 60 * 1000L;
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
+    private final RefreshRepository refreshRepository;
+
+    public LoginFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil, CookieUtil cookieUtil, RefreshRepository refreshRepository) {
+        super.setFilterProcessesUrl("/api/login");
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+        this.cookieUtil = cookieUtil;
+        this.refreshRepository = refreshRepository;
+    }
+
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            // POST 요청이 아닌 경우 인증을 시도하지 않음
+            return null;
+        }
+
+        LoginDTO loginDTO = new LoginDTO();
+
+        try {
+            InputStream inputStream = request.getInputStream();
+            ObjectMapper mapper = new ObjectMapper();
+            String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+            loginDTO = mapper.readValue(messageBody, LoginDTO.class);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+
+        String loginId = loginDTO.getLoginId();
+        String password = loginDTO.getPassword();
+
+        log.info("loginid = [{}], " +
+                "password = [{}]", loginId, password);
+
+        try {
+            UsernamePasswordAuthenticationToken authToken =
+                    new UsernamePasswordAuthenticationToken(loginId, password, null);
+            log.info("authToken = [{}]", authToken);
+
+            // AuthenticationManager에 인증 요청
+            return this.authenticationManager.authenticate(authToken);
+        } catch (Exception ex) {
+            log.error("\"Error during authentication: \" + ex.getMessage()");
+            throw ex; // 문제의 원인을 추적하기 위해 예외 재던짐
+        }
+    }
+
+    @Override
+
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                            FilterChain chain, Authentication authResult) throws IOException, ServletException {
+
+
+        String userId = authResult.getName();
+
+        Collection<? extends GrantedAuthority> authorities = authResult.getAuthorities();
+        if (authorities.isEmpty()) {
+            log.error("Granted Authorities are empty!");
+            throw new RuntimeException("User has no granted authorities");
+        }
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+        // 토큰 생성
+        String access = jwtUtil.createJwt("access",userId, role, ACCESSMS);
+        String refresh = jwtUtil.createJwt("refresh",userId, role, REFRESHMS);
+        log.info("로그인 성공");
+
+        //Refresh 토큰 저장
+        addRefreshEntity(userId, refresh, REFRESHMS);
+
+        // 응답설정
+        response.setHeader("access", access);
+        response.addCookie(cookieUtil.createCookie("refresh", refresh));
+        response.setStatus(HttpStatus.OK.value());
+
+    }
+
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+        log.error("로그인 실패");
+        response.setStatus(401);
+
+    }
+
+    private void addRefreshEntity(String userId, String refresh, Long expiredMs) {
+
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUserId(userId);
+        refreshToken.setRefresh(refresh);
+        refreshToken.setExpiration(String.valueOf(new Timestamp(date.getTime())));
+
+        refreshRepository.save(refreshToken);
+    }
+
+}

--- a/src/main/java/DevBackEnd/ForLong/Repository/OAuth2UserInfo.java
+++ b/src/main/java/DevBackEnd/ForLong/Repository/OAuth2UserInfo.java
@@ -1,0 +1,10 @@
+package DevBackEnd.ForLong.Repository;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getProvider();
+    String getName();
+    String getNickname();
+    String getEmail();
+    String getMobile();
+}

--- a/src/main/java/DevBackEnd/ForLong/Repository/RefreshRepository.java
+++ b/src/main/java/DevBackEnd/ForLong/Repository/RefreshRepository.java
@@ -1,0 +1,14 @@
+package DevBackEnd.ForLong.Repository;
+
+import DevBackEnd.ForLong.Entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public interface RefreshRepository extends JpaRepository<RefreshToken, Long> {
+    Boolean existsByRefresh(String refresh);
+
+    @Transactional
+    void deleteByRefresh(String refresh);
+}

--- a/src/main/java/DevBackEnd/ForLong/Repository/UserRepository.java
+++ b/src/main/java/DevBackEnd/ForLong/Repository/UserRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     User save(User user);
-    boolean existsByJoinId(String joinId);
-    User findByJoinId(String joinId);
+    boolean existsByLoginId(String loginId);
+    User findByLoginId(String loginId);
 }

--- a/src/main/java/DevBackEnd/ForLong/Repository/UserRepository.java
+++ b/src/main/java/DevBackEnd/ForLong/Repository/UserRepository.java
@@ -2,7 +2,9 @@ package DevBackEnd.ForLong.Repository;
 
 import DevBackEnd.ForLong.Entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     User save(User user);

--- a/src/main/java/DevBackEnd/ForLong/Service/JoinService.java
+++ b/src/main/java/DevBackEnd/ForLong/Service/JoinService.java
@@ -25,10 +25,10 @@ public class JoinService {
 
     @Transactional
     public User saveUser(JoinDTO joinDTO){
-        String joinId = joinDTO.getUserId();
+        String loginId = joinDTO.getLoginId();
 
-        if(userRepository.existsByJoinId(joinId)){
-           log.info("중복된 userId : {}", joinId);
+        if(userRepository.existsByLoginId(loginId)){
+           log.info("중복된 userId : {}", loginId);
            throw new IllegalArgumentException("중복된 아이디가 있습니다.");
         }
         joinDTO.setPassword(passwordUtil.encodePassword(joinDTO.getPassword()));
@@ -62,7 +62,7 @@ public class JoinService {
         }
         log.info("회원 정보 저장 완료 : {}", user);
 
-        return userRepository.findByJoinId(joinDTO.getUserId());
+        return userRepository.findByLoginId(joinDTO.getLoginId());
     }
 
     public String phoneNumCleaner(String phone){

--- a/src/main/java/DevBackEnd/ForLong/Service/JoinService.java
+++ b/src/main/java/DevBackEnd/ForLong/Service/JoinService.java
@@ -25,7 +25,7 @@ public class JoinService {
 
     @Transactional
     public User saveUser(JoinDTO joinDTO){
-        String loginId = joinDTO.getLoginId();
+        String loginId = joinDTO.getLogin_id();
 
         if(userRepository.existsByLoginId(loginId)){
            log.info("중복된 userId : {}", loginId);
@@ -62,7 +62,7 @@ public class JoinService {
         }
         log.info("회원 정보 저장 완료 : {}", user);
 
-        return userRepository.findByLoginId(joinDTO.getLoginId());
+        return userRepository.findByLoginId(joinDTO.getLogin_id());
     }
 
     public String phoneNumCleaner(String phone){

--- a/src/main/java/DevBackEnd/ForLong/Util/CookieUtil.java
+++ b/src/main/java/DevBackEnd/ForLong/Util/CookieUtil.java
@@ -1,0 +1,19 @@
+package DevBackEnd.ForLong.Util;
+
+import jakarta.servlet.http.Cookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60*60); // 쿠키가 살아있을 시간
+        //cookie.setSecure(true);  //https 일 경우 주석 삭제
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/DevBackEnd/ForLong/Util/JwtUtil.java
+++ b/src/main/java/DevBackEnd/ForLong/Util/JwtUtil.java
@@ -1,0 +1,73 @@
+package DevBackEnd.ForLong.Util;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private SecretKey secretKey;
+
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+
+    }
+
+    /**
+     * 유저 아이디를 가져오는 메서드
+     * Jwts.parser().verifyWith(secretKey) :secretKey를 사용하여 JWT의 서명을 검증
+     * parseSignedClaims : 클래임 확인
+     * getPayload().get("userId", String.class) userId key를 가져옴
+     * **/
+    public String getUserId(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("loginId", String.class);
+    }
+
+    /**
+     * 유저 역할 확인하는 메서드
+     * **/
+    public String getRole(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+    
+    /**
+     * 토큰 만료 했는지 검증하는 메서드
+     * **/
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String getCategory(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
+    /**
+     * 토큰 생성 메서드
+     * userId : 유저아이디
+     * role : 역할
+     * expiredMs : 만료시간
+     * **/
+    public String createJwt(String category,String loginId, String role, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("loginId", loginId)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis())) // 생성시간
+                .expiration(new Date(System.currentTimeMillis() + expiredMs)) // 만료시간
+                .signWith(secretKey)
+                .compact();
+    }
+
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,13 @@ spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
+
+spring.jwt.secret = ${JWT_CODE}
+
+logging.level.org.springframework.security=DEBUG
+
+
 
 # Hibernate 가 실행하는 SQL 쿼리를 로그에 출력
 #spring.jpa.show-sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 
 # Hibernate 가 실행하는 SQL 쿼리를 로그에 출력
 #spring.jpa.show-sql=true

--- a/src/main/resources/properties/env.properties
+++ b/src/main/resources/properties/env.properties
@@ -2,3 +2,5 @@
 DB_URL=jdbc:mysql://13.124.36.91:3306/ForLong
 DB_USERNAME=test
 DB_PASSWORD=1234
+
+JWT_CODE=asdgasdf5as1gasdf5465asdg12asdf65fewf


### PR DESCRIPTION

  <br/>

## 🔎 작업 내용

-  기본 로그인은 loginId, password를 dto를 통해 받아서 LoginFilter단에서 인증 로직 수행 후, jwt 토큰 ( accessToken 및 refershToken) 생성,
- refreshToken은 DB에 저장.

- 로그아웃 하면 DB에 저장 되어있는 RefreshToken 삭제

- 프론트 개발자를 위한 api 명세서 자동화를 위한 임의의 controller 추가

  <br/>

## 이미지 첨부

1. 로그인 관련 테스트
![image](https://github.com/user-attachments/assets/6668d0b6-01e6-4ee5-ac6d-790f31de348f)
![image](https://github.com/user-attachments/assets/a73b1f34-82b3-4e7b-b98c-9a3cc71c650a)

2. 로그아웃 관련 테스트
![image](https://github.com/user-attachments/assets/eef3d224-ca71-46cd-a689-f7fe6fd80952)
![image](https://github.com/user-attachments/assets/8740a71e-b023-420a-9efe-ad0b56f3fc21)

3. 현재까지 api명세서
![image](https://github.com/user-attachments/assets/076c379e-86a9-45ba-a161-2d3e02e214f7)


<br/>

## 🔧 앞으로의 과제

- 네이버 소셜 로그인 관련 로직 구현

  <br/>



<br/>