### PR TITLE
feat(6) : OAuth2 Naver Login & JWT Refresh Token 

### DIFF
--- a/src/main/java/DevBackEnd/ForLong/Config/NaverConfig.java
+++ b/src/main/java/DevBackEnd/ForLong/Config/NaverConfig.java
@@ -1,0 +1,20 @@
+package DevBackEnd.ForLong.Config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+@Getter
+@Component(value = "naverApi")
+public class NaverConfig {
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String NaverClientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.redirect-uri}")
+    private String NaverRedirectUri;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String NaverClientSecret;
+}

--- a/src/main/java/DevBackEnd/ForLong/Controller/LoginController.java
+++ b/src/main/java/DevBackEnd/ForLong/Controller/LoginController.java
@@ -1,0 +1,14 @@
+package DevBackEnd.ForLong.Controller;
+
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class LoginController {
+
+    @GetMapping("/login")
+    public String login() {
+        return "login";
+    }
+}

--- a/src/main/java/DevBackEnd/ForLong/Controller/OAuth2LoginTestController.java
+++ b/src/main/java/DevBackEnd/ForLong/Controller/OAuth2LoginTestController.java
@@ -1,12 +1,10 @@
 package DevBackEnd.ForLong.Controller;
 
-
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
-public class LoginController {
-
+public class OAuth2LoginTestController {
     @GetMapping("/login")
     public String login() {
         return "login";

--- a/src/main/java/DevBackEnd/ForLong/Controller/UserController.java
+++ b/src/main/java/DevBackEnd/ForLong/Controller/UserController.java
@@ -1,16 +1,15 @@
 package DevBackEnd.ForLong.Controller;
 
+
 import DevBackEnd.ForLong.Dto.ApiResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api")
@@ -18,7 +17,7 @@ public class UserController {
 
     /**
      * 실제 로그인 로직은 LoginFilter를 통해 구현됨.
-     * 이 코드는 프론트앤드 개발자를 위한 명세서를 위해 적은 코드
+     * 프론트 개발자를 위한 api 명세서를 위한 코드
      * */
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공 시 JWT 토큰 반환"),
@@ -36,6 +35,33 @@ public class UserController {
 
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * oAuth2 소셜 로그인 설명
+     * 실제로는 Filter 단에서 작동 됨.
+     * 프론트 개발자를 위한 api 명세서를 위한 코드
+     * */
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "302", description = "소셜 로그인 페이지로 리디렉션"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @Operation(summary = "OAuth2 소셜 로그인 (Swagger 명세 전용)",
+            description = "앤드포인트 -> /oauth2/authorization/{provider}" +
+                    "사용자가 /oauth2/authorization/{provider}로 리디렉션하면 해당 소셜 로그인 페이지로 이동합니다. 로그인 성공 시 서버는 JWT 토큰을 쿠키에 저장하고, " +
+                    "클라이언트는 이후 요청에서 해당 토큰을 활용하여 인증할 수 있습니다. 실제 요청 처리가 아닌 명세용 설명입니다." +
+                    "클라이언트가 /oauth2/authorization/naver로 접근하면 Spring Security의 OAuth2 설정에 따라 자동으로 네이버 로그인 로직이 실행됩니다. " +
+                    "그리고 로그인에 성공하면 커스텀 성공 핸들러(CustomOAuth2SuccessHandler)가 작동하여 JWT 토큰을 발급하고, 이를 클라이언트에게 쿠키로 전달" +
+                    "쿠키의 만료 시간은 1시간"
+    )
+    @GetMapping("/oauth2/authorization/{provider}")
+    public ResponseEntity<ApiResponseDTO<Void>> oauth2Login(
+            @Parameter(description = "소셜 로그인 제공자 (예: google, facebook, github)", required = true)
+            @PathVariable String provider) {
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .body(new ApiResponseDTO<>("redirect", "소셜 로그인 페이지로 리디렉션", null));
+    }
+
+
 
     /**
      * 로그아웃

--- a/src/main/java/DevBackEnd/ForLong/Converter/JoinConverter.java
+++ b/src/main/java/DevBackEnd/ForLong/Converter/JoinConverter.java
@@ -14,7 +14,9 @@ public class JoinConverter {
                 user.getNickname(),
                 user.getEmail(),
                 user.getPhone(),
-                user.getRole()
+                user.getRole(),
+                user.getProviderId(),
+                user.getProvider()
         );
     }
 

--- a/src/main/java/DevBackEnd/ForLong/Dto/JoinDTO.java
+++ b/src/main/java/DevBackEnd/ForLong/Dto/JoinDTO.java
@@ -1,5 +1,6 @@
 package DevBackEnd.ForLong.Dto;
 
+import jakarta.persistence.Column;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,14 +14,18 @@ public class JoinDTO {
     private String email;
     private String phone;
     private String role;
+    private String provider;
+    private String provider_id;
 
     public JoinDTO(String loginId, String password, String nickname,
-                   String email, String phone, String role){
+                   String email, String phone, String role,String provider, String provider_id){
         this.login_id = loginId;
         this.password = password;
         this.nickname = nickname;
         this.email = email;
         this.phone = phone;
         this.role = role;
+        this.provider = provider;
+        this.provider_id = provider_id;
     }
 }

--- a/src/main/java/DevBackEnd/ForLong/Dto/NaverUserDetails.java
+++ b/src/main/java/DevBackEnd/ForLong/Dto/NaverUserDetails.java
@@ -1,0 +1,50 @@
+package DevBackEnd.ForLong.Dto;
+
+import DevBackEnd.ForLong.Repository.OAuth2UserInfo;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+@Slf4j
+public class NaverUserDetails implements OAuth2UserInfo {
+
+    private Map<String,Object> attributes;
+    private Map<String, Object> response;
+
+    public NaverUserDetails(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.response = (Map<String, Object>) attributes.get("response");
+    }
+
+    @Override
+    public String getProviderId() {
+        if (response != null && response.containsKey("id")) {
+            return (String) response.get("id");
+        } else if (attributes.containsKey("id")) {
+            return (String) attributes.get("id");
+        } else {
+            log.error("Provider ID를 찾을 수 없습니다.");
+            return null;
+        }
+    }
+
+    @Override
+    public String getProvider() {
+        return "Naver";
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) response.get("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) response.get("email");
+    }
+
+    @Override
+    public String getMobile() {
+        return (String) response.get("mobile");
+    }
+}

--- a/src/main/java/DevBackEnd/ForLong/Filter/CustomOAuth2FailuerHandler.java
+++ b/src/main/java/DevBackEnd/ForLong/Filter/CustomOAuth2FailuerHandler.java
@@ -1,0 +1,40 @@
+package DevBackEnd.ForLong.Filter;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+
+@Slf4j
+@Component
+public class CustomOAuth2FailuerHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        String redirectUri = request.getParameter("redirect_uri");
+        String errorMessage;
+        int statusCode;
+
+        if (redirectUri == null || redirectUri.isEmpty()) {
+            log.info("400 오류 발생");
+            errorMessage = "Missing or invalid redirect_url parameter";
+            statusCode = HttpServletResponse.SC_BAD_REQUEST;
+        } else{
+            log.info("500 오류 발생");
+            errorMessage ="OAuth2 authentication failed due to a server error.";
+            statusCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+        }
+
+        response.setStatus(statusCode);
+        response.setContentType("application/json;charset=UTF-8");
+
+        response.getWriter().write(String.format("{\"error\": \"%s\", \"status\": %d}", errorMessage, statusCode));
+    }
+}

--- a/src/main/java/DevBackEnd/ForLong/Filter/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/DevBackEnd/ForLong/Filter/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,32 @@
+package DevBackEnd.ForLong.Filter;
+
+import DevBackEnd.ForLong.Dto.CustomUserDetail;
+import DevBackEnd.ForLong.Entity.RefreshToken;
+import DevBackEnd.ForLong.Repository.RefreshRepository;
+import DevBackEnd.ForLong.Util.CookieUtil;
+import DevBackEnd.ForLong.Util.JwtUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication auth) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"message\": \"Authentication successful.\"}");
+    }
+
+
+}

--- a/src/main/java/DevBackEnd/ForLong/Repository/OAuth2UserInfo.java
+++ b/src/main/java/DevBackEnd/ForLong/Repository/OAuth2UserInfo.java
@@ -3,7 +3,6 @@ package DevBackEnd.ForLong.Repository;
 public interface OAuth2UserInfo {
     String getProviderId();
     String getProvider();
-    String getName();
     String getNickname();
     String getEmail();
     String getMobile();

--- a/src/main/java/DevBackEnd/ForLong/Repository/RefreshRepository.java
+++ b/src/main/java/DevBackEnd/ForLong/Repository/RefreshRepository.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public interface RefreshRepository extends JpaRepository<RefreshToken, Long> {
     Boolean existsByRefresh(String refresh);
+    void save(String refresh);
 
     @Transactional
     void deleteByRefresh(String refresh);

--- a/src/main/java/DevBackEnd/ForLong/Service/CustomOauth2UserService.java
+++ b/src/main/java/DevBackEnd/ForLong/Service/CustomOauth2UserService.java
@@ -1,0 +1,118 @@
+package DevBackEnd.ForLong.Service;
+
+import DevBackEnd.ForLong.Converter.JoinConverter;
+import DevBackEnd.ForLong.Dto.CustomUserDetail;
+import DevBackEnd.ForLong.Dto.JoinDTO;
+import DevBackEnd.ForLong.Dto.NaverUserDetails;
+import DevBackEnd.ForLong.Entity.RefreshToken;
+import DevBackEnd.ForLong.Entity.User;
+import DevBackEnd.ForLong.Repository.OAuth2UserInfo;
+import DevBackEnd.ForLong.Repository.RefreshRepository;
+import DevBackEnd.ForLong.Repository.UserRepository;
+import DevBackEnd.ForLong.Util.CookieUtil;
+import DevBackEnd.ForLong.Util.HashUtil;
+import DevBackEnd.ForLong.Util.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class CustomOauth2UserService extends DefaultOAuth2UserService {
+
+    public static final long REFRESHMS = 24 * 60 * 60 * 1000L;
+    private final UserRepository userRepository;
+    private final RefreshRepository refreshRepository;
+    private final CookieUtil cookieUtil;
+    private final JwtUtil jwtUtil;
+    private final JoinService joinService;
+    private final HttpServletResponse response;
+    private final HttpSession session;
+
+
+    public CustomOauth2UserService(UserRepository userRepository, RefreshRepository refreshRepository, CookieUtil cookieUtil, JwtUtil jwtUtil,
+                                   JoinService joinService, HttpServletResponse response, HttpSession session) {
+        this.userRepository = userRepository;
+        this.refreshRepository = refreshRepository;
+        this.cookieUtil = cookieUtil;
+        this.jwtUtil = jwtUtil;
+        this.joinService = joinService;
+        this.response = response;
+        this.session = session;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(request);
+
+        return processOAuth2User(request,oAuth2User);
+    }
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest request, OAuth2User oAuth2User) {
+
+        String provider = request.getClientRegistration().getClientName();
+        OAuth2UserInfo oAuth2UserInfo = null;
+
+        if(provider.equals("naver")){
+            log.info("네이버 로그인 요청");
+            oAuth2UserInfo = new NaverUserDetails(oAuth2User.getAttributes());
+        } else if (provider.equals("kakao")) {
+            log.info("카카오 로그인 요청");
+        }
+
+        String providerId = oAuth2UserInfo.getProviderId();
+        String loginId = oAuth2UserInfo.getEmail();
+        String nickname = oAuth2UserInfo.getNickname();
+        String role = "ROLE_OAUTH2_USER";
+        String email = oAuth2UserInfo.getEmail();
+        String phone = oAuth2UserInfo.getMobile();
+//        Optional<User> userOptional = Optional.ofNullable(userRepository.findByLoginId(loginId));
+
+        User user = userRepository.findByLoginId(loginId);
+
+        if (user == null){
+            String cleanPhone = phone.replaceAll("-", "");
+            String HashedPhone = HashUtil.hashPhoneNum(cleanPhone);
+
+            JoinDTO joinDTO = new JoinDTO(loginId,"OAuth2 default value",nickname,email,HashedPhone,
+                    role,provider,providerId);
+            log.info("신규 회원 저장 시도: {}", loginId);
+            User savedUser = joinService.saveUser(joinDTO);
+            log.info("신규 회원 저장 완료 : {}", joinDTO);
+
+            String refresh = jwtUtil.createJwt("refresh", loginId, role, REFRESHMS);
+            session.setAttribute("refresh", refresh);
+            response.addCookie(cookieUtil.createCookie("refresh", refresh));
+            log.info("refresh 토큰 저장 시도");
+            addRefreshEntity(loginId,refresh,REFRESHMS);
+            log.info("refresh 토큰 저장 완료");
+
+            return new CustomUserDetail(savedUser, oAuth2User.getAttributes());
+        }
+
+        log.info("기존 사용자 로그인 : {}, {}", loginId, user);
+        return new CustomUserDetail(user, oAuth2User.getAttributes());
+
+    }
+
+    private void addRefreshEntity(String loginId, String refresh, Long expiredMs) {
+
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshToken refreshEntity = new RefreshToken();
+        refreshEntity.setUserId(loginId);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
+
+}

--- a/src/main/java/DevBackEnd/ForLong/Service/CustomUserDetailService.java
+++ b/src/main/java/DevBackEnd/ForLong/Service/CustomUserDetailService.java
@@ -1,5 +1,6 @@
-package DevBackEnd.ForLong.Dto;
+package DevBackEnd.ForLong.Service;
 
+import DevBackEnd.ForLong.Dto.CustomUserDetail;
 import DevBackEnd.ForLong.Entity.User;
 import DevBackEnd.ForLong.Repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +27,11 @@ public class CustomUserDetailService implements UserDetailsService {
         if (user == null) {
             throw new UsernameNotFoundException("User not found : " + loginId);
         }
+        if (user.getPassword() == null) {
+            return new CustomUserDetail(user,null);
+        }
         return new CustomUserDetail(user,null);
     }
+
+
 }

--- a/src/main/java/DevBackEnd/ForLong/Service/JoinService.java
+++ b/src/main/java/DevBackEnd/ForLong/Service/JoinService.java
@@ -16,11 +16,10 @@ import org.springframework.stereotype.Service;
 public class JoinService {
 
     private final UserRepository userRepository;
-    private final PasswordUtil passwordUtil;
+    private final PasswordUtil passwordUtil = new PasswordUtil(new BCryptPasswordEncoder());
 
-    public JoinService(UserRepository userRepository, PasswordUtil passwordUtil) {
+    public JoinService(UserRepository userRepository) {
         this.userRepository = userRepository;
-        this.passwordUtil = passwordUtil;
     }
 
     @Transactional

--- a/src/main/java/DevBackEnd/ForLong/Util/HashUtil.java
+++ b/src/main/java/DevBackEnd/ForLong/Util/HashUtil.java
@@ -1,12 +1,11 @@
 package DevBackEnd.ForLong.Util;
 
-import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-@Component
+
 public class HashUtil {
     public static String hashPhoneNum(String phone){
         try{

--- a/src/main/java/DevBackEnd/ForLong/Util/PasswordUtil.java
+++ b/src/main/java/DevBackEnd/ForLong/Util/PasswordUtil.java
@@ -3,7 +3,6 @@ package DevBackEnd.ForLong.Util;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
-@Component
 public class PasswordUtil {
 
     private final BCryptPasswordEncoder bCryptPasswordEncoder;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,17 @@ spring.jwt.secret = ${JWT_CODE}
 
 logging.level.org.springframework.security=DEBUG
 
+# NAVER API 설정
+spring.security.oauth2.client.registration.naver.client-id=${NAVER_CLIENTID}
+spring.security.oauth2.client.registration.naver.client-secret=${NAVER_SERCRET}
+spring.security.oauth2.client.registration.naver.redirect-uri=${NAVER_REDIRECT}
+spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.naver.client-name=naver
 
+spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
+spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
+spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
+spring.security.oauth2.client.provider.naver.user-name-attribute=response
 
 # Hibernate 가 실행하는 SQL 쿼리를 로그에 출력
 #spring.jpa.show-sql=true

--- a/src/main/resources/properties/env.properties
+++ b/src/main/resources/properties/env.properties
@@ -4,3 +4,7 @@ DB_USERNAME=test
 DB_PASSWORD=1234
 
 JWT_CODE=asdgasdf5as1gasdf5465asdg12asdf65fewf
+
+NAVER_SERCRET=5yNgS8jQW5
+NAVER_CLIENTID=3_yku65z39OX6tkZnY1J
+NAVER_REDIRECT=http://localhost:8080/login/oauth2/code/naver

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>로그인</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f5f5f5;
+        }
+        .container {
+            width: 50%;
+            margin: 50px auto;
+            background-color: #fff;
+            padding: 20px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            text-align: center;
+        }
+        .form-group {
+            margin-bottom: 20px;
+        }
+        .form-group label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        .form-group input {
+            width: 100%;
+            padding: 10px;
+            font-size: 16px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+        }
+        .button-group {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+            margin-top: 20px;
+        }
+        button {
+            padding: 10px 20px;
+            font-size: 16px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            background-color: #4CAF50;
+            color: #fff;
+        }
+        .find-button {
+            background-color: #008CBA;
+        }
+        .error {
+            color: red;
+            margin-top: 20px;
+        }
+    </style>
+    <script>
+        function openPopup(url, title) {
+            window.open(url, title, "width=500,height=400,scrollbars=no,resizable=no");
+        }
+    </script>
+</head>
+<body>
+<div class="container">
+    <h1>로그인</h1>
+    <form action="/loginProc" method="post">
+
+        <div class="form-group">
+            <label for="userId">아이디</label>
+            <input type="text" id="userId" name="userId" placeholder="아이디를 입력하세요" required>
+        </div>
+        <div class="form-group">
+            <label for="password">패스워드</label>
+            <input type="password" id="password" name="password" placeholder="비밀번호를 입력하세요" required>
+        </div>
+
+        <div class="button-group">
+            <button type="submit">로그인</button>
+            <a href="/certifyUser"><button type="button" class="find-button">비밀번호 찾기</button></a>
+        </div>
+    </form>
+
+    <p> </p>
+    <div id="naver_id_login"></div>
+
+    <a th:href="@{/oauth2/authorization/naver}">
+        <button type="button">네이버 로그인</button>
+    </a>
+
+    <div th:if="${errorMsg != null}" class="error">
+        <p th:text="${errorMsg}"></p>
+    </div>
+</div>
+
+
+</body>
+</html>


### PR DESCRIPTION
## 제목 : feat(issue 번호): 기능명
  ex) feat(17): pull request template 작성
  (확인 후 지워주세요)


  <br/>

## 🔎 작업 내용

- 네이버 소셜 로그인 기능 구현
- 첫 회원은 비밀번호 default_password_value 로 저장 
- refresh 토큰 저장, 만료 시간 1시간 (24 * 60 * 60 * 1000L;)
- api 문서화 자동화를 위한 코드 작성
- test를 위한 임시 html View 작성, localhost8080/login 으로 들어가면 테스트 가능

  <br/>

## 이미지 첨부

https://github.com/user-attachments/assets/1757fc32-b6aa-46c6-9981-187a9cc272d1

![image](https://github.com/user-attachments/assets/43951084-2e4e-4f22-af9f-2182daee7a39)

![image](https://github.com/user-attachments/assets/81b6af2a-9db4-4efa-9cbb-df6a55366336)

![image](https://github.com/user-attachments/assets/9cb045dd-c0b0-4b88-832e-e0243d75a366)


<br/>

## 🔧 앞으로의 과제

- 카카오 로그인 구현

  <br/>



<br/>